### PR TITLE
Issue#1 - Response field name is different

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var https = require('https');
 exports.verify = function(secret) {
 	
 	return function(req,res,next) {
-		var responseString = req.body['gRecaptchaResponse'];
+		var responseString = req.body['g-recaptcha-response'];
 
 		var options = {
 		  hostname: 'www.google.com',


### PR DESCRIPTION
Fix for Issue#1 - Response field name is different

Response field added by google is named as "g-recaptcha-response" rather than "gRecaptchaRespons". 
https://developers.google.com/recaptcha/docs/verify
